### PR TITLE
Fixes drawer snap behaviour

### DIFF
--- a/Pulley/DrawerContentViewController.swift
+++ b/Pulley/DrawerContentViewController.swift
@@ -93,7 +93,7 @@ extension DrawerContentViewController: PulleyDrawerViewControllerDelegate {
     }
     
     func supportedDrawerPositions() -> [PulleyPosition] {
-        return PulleyPosition.all // You can specify the drawer positions you support. This is the same as: [.open, .partiallyRevealed, .collapsed, .closed]
+        return PulleyPosition.artsy // You can specify the drawer positions you support. This is the same as: [.open, .partiallyRevealed, .collapsed, .closed]
     }
     
     // This function is called by Pulley anytime the size, drawer position, etc. changes. It's best to customize your VC UI based on the bottomSafeArea here (if needed). Note: You might also find the `pulleySafeAreaInsets` property on Pulley useful to get Pulley's current safe area insets in a backwards compatible (with iOS < 11) way. If you need this information for use in your layout, you can also access it directly by using `drawerDistanceFromBottom` at any time.

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -538,7 +538,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
     }
     
     /// Get the drawer scrollview's pan gesture recognizer
-    public var drawerPanGestureRecognizer: UIPanGestureRecognizer {
+    @objc public var drawerPanGestureRecognizer: UIPanGestureRecognizer {
         get {
             return drawerScrollView.panGestureRecognizer
         }

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -190,8 +190,6 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
     fileprivate let backgroundDimmingView: UIView = UIView()
     
     fileprivate var dimmingViewTapRecognizer: UITapGestureRecognizer?
-    
-    fileprivate var lastDragTargetContentOffset: CGPoint = CGPoint.zero
 
     // Public
     
@@ -1487,14 +1485,16 @@ extension PulleyViewController: PulleyPassthroughScrollViewDelegate {
 
 extension PulleyViewController: UIScrollViewDelegate {
 
-    public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
         
         if scrollView == drawerScrollView
         {
+            let lastDragTargetContentOffset = targetContentOffset.pointee
+
             // Find the closest anchor point and snap there.
-            var collapsedHeight:CGFloat = kPulleyDefaultCollapsedHeight
-            var partialRevealHeight:CGFloat = kPulleyDefaultPartialRevealHeight
-            
+            var collapsedHeight: CGFloat = kPulleyDefaultCollapsedHeight
+            var partialRevealHeight: CGFloat = kPulleyDefaultPartialRevealHeight
+
             if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate
             {
                 collapsedHeight = drawerVCCompliant.collapsedDrawerHeight?(bottomSafeArea: pulleySafeAreaInsets.bottom) ?? kPulleyDefaultCollapsedHeight
@@ -1503,43 +1503,43 @@ extension PulleyViewController: UIScrollViewDelegate {
 
             var drawerStops: [CGFloat] = [CGFloat]()
             var currentDrawerPositionStop: CGFloat = 0.0
-            
+
             if supportedPositions.contains(.open)
             {
                 drawerStops.append(heightOfOpenDrawer)
-                
+
                 if drawerPosition == .open
                 {
                     currentDrawerPositionStop = drawerStops.last!
                 }
             }
-            
+
             if supportedPositions.contains(.partiallyRevealed)
             {
                 drawerStops.append(partialRevealHeight)
-                
+
                 if drawerPosition == .partiallyRevealed
                 {
                     currentDrawerPositionStop = drawerStops.last!
                 }
             }
-            
+
             if supportedPositions.contains(.collapsed)
             {
                 drawerStops.append(collapsedHeight)
-                
+
                 if drawerPosition == .collapsed
                 {
                     currentDrawerPositionStop = drawerStops.last!
                 }
             }
-            
+
             let lowestStop = drawerStops.min() ?? 0
-            
+
             let distanceFromBottomOfView = lowestStop + lastDragTargetContentOffset.y
-            
+
             var currentClosestStop = lowestStop
-            
+
             for currentStop in drawerStops
             {
                 if abs(currentStop - distanceFromBottomOfView) < abs(currentClosestStop - distanceFromBottomOfView)
@@ -1547,9 +1547,9 @@ extension PulleyViewController: UIScrollViewDelegate {
                     currentClosestStop = currentStop
                 }
             }
-            
+
             var closestValidDrawerPosition: PulleyPosition = drawerPosition
-            
+
             if abs(Float(currentClosestStop - heightOfOpenDrawer)) <= Float.ulpOfOne && supportedPositions.contains(.open)
             {
                 closestValidDrawerPosition = .open
@@ -1562,19 +1562,12 @@ extension PulleyViewController: UIScrollViewDelegate {
             {
                 closestValidDrawerPosition = .partiallyRevealed
             }
-            
+
             let snapModeToUse: PulleySnapMode = closestValidDrawerPosition == drawerPosition ? snapMode : .nearestPosition
-            
-            switch snapModeToUse {
-                
-            case .nearestPosition:
-                
-                setDrawerPosition(position: closestValidDrawerPosition, animated: true)
-                
-            case .nearestPositionUnlessExceeded(let threshold):
-                
+
+            if case .nearestPositionUnlessExceeded(let threshold) = snapModeToUse {
                 let distance = currentDrawerPositionStop - distanceFromBottomOfView
-                
+
                 var positionToSnapTo: PulleyPosition = drawerPosition
 
                 if abs(distance) > threshold
@@ -1595,7 +1588,7 @@ extension PulleyViewController: UIScrollViewDelegate {
                     else
                     {
                         let orderedSupportedDrawerPositions = supportedPositions.sorted(by: { $0.rawValue > $1.rawValue }).filter({ $0 != .closed })
-                        
+
                         for position in orderedSupportedDrawerPositions
                         {
                             if position.rawValue < drawerPosition.rawValue
@@ -1606,20 +1599,36 @@ extension PulleyViewController: UIScrollViewDelegate {
                         }
                     }
                 }
-                
-                setDrawerPosition(position: positionToSnapTo, animated: true)
+
+                closestValidDrawerPosition = positionToSnapTo
             }
-        }
-    }
-    
-    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-        
-        if scrollView == drawerScrollView
-        {
-            lastDragTargetContentOffset = targetContentOffset.pointee
-            
-            // Halt intertia
-            targetContentOffset.pointee = scrollView.contentOffset
+
+            self.drawerPosition = closestValidDrawerPosition
+
+            let stopToMoveTo: CGFloat
+
+            switch drawerPosition {
+
+            case .collapsed:
+                stopToMoveTo = collapsedHeight
+
+            case .partiallyRevealed:
+                stopToMoveTo = partialRevealHeight
+
+            case .open:
+                stopToMoveTo = heightOfOpenDrawer
+
+            case .closed:
+                stopToMoveTo = 0
+
+            default:
+                stopToMoveTo = 0
+            }
+
+            triggerFeedbackGenerator()
+
+            let desiredComputedDrawerPositionContentOffset = CGPoint(x: 0, y: stopToMoveTo - lowestStop)
+            targetContentOffset.pointee = desiredComputedDrawerPositionContentOffset
         }
     }
     

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -1629,6 +1629,12 @@ extension PulleyViewController: UIScrollViewDelegate {
 
             let desiredComputedDrawerPositionContentOffset = CGPoint(x: 0, y: stopToMoveTo - lowestStop)
             targetContentOffset.pointee = desiredComputedDrawerPositionContentOffset
+
+            self.delegate?.drawerPositionDidChange?(drawer: self, bottomSafeArea: self.pulleySafeAreaInsets.bottom)
+            (self.drawerContentViewController as? PulleyDrawerViewControllerDelegate)?.drawerPositionDidChange?(drawer: self, bottomSafeArea: self.pulleySafeAreaInsets.bottom)
+            (self.primaryContentViewController as? PulleyPrimaryContentControllerDelegate)?.drawerPositionDidChange?(drawer: self, bottomSafeArea: self.pulleySafeAreaInsets.bottom)
+
+            self.view.layoutIfNeeded()
         }
     }
     


### PR DESCRIPTION
This is a follow-up to the Emission PR here: https://github.com/artsy/emission/pull/1412 It requires a bit of explaining.

Pulley uses a bounceless scroll view to mimic a drawer. To get the drawer to 'snap to' its supported positions (closed, open, partially revealed), it was doing this weird kind of dance:

- Use `scrollViewWillEndDragging` delegate callback to remember the `targetContentOffset`, and to modify its pointer to the scroll view's current content offset (to halt its momentum).
- Use the subsequent `scrollViewDidEndDragging` delegate callback to calculate where the scroll view should snap _to_, based on the previously-set `targetContentOffset`.

This approach wasn't working for us in Emission, I think because of how we [modify scroll view behaviour for React Native](https://github.com/artsy/emission/blob/master/Pod/Classes/Core/RCTScrollView%2BEnclosingScrollView.m). Instead of doing this two-step dance where we stop scrolling, then use a common code path to set the drawer position, I have modified the library to use `scrollViewWillEndDragging` as Apple intended: to modify its `targetContentOffset` pointer to where we're going to snap to. This introduces a slight bit of code duplication (the code is copied from `setDrawerPosition`) but gives us the exact behaviour we want.

<details>
<summary>GIF of the app working</summary>

![working gifcask 2019-03-08 10_52_55](https://user-images.githubusercontent.com/498212/54039200-59406800-4190-11e9-84b5-cb69e7667c10.gif)

</details>

You'll notice in the GIF that the drawer has a more natural deceleration. We can further customize this rate as we need to.

~What I found _very_ interesting was that this change actually _introduces_ the same bug we're fixing in Emission to the Pulley example app:~

*EDIT*: This bug was caused by me not copying the delegate calls (we don't use them, currently). I've added them here to avoid headaches down the road: 
https://github.com/l2succes/Pulley/pull/3/commits/eb91e36b68375d1728e0c3a3b31360e2bd890fa5

<details>
<summary>GIF of the Pulley example app exhibiting the bug</summary>


![bad gifcask 2019-03-08 10_48_51](https://user-images.githubusercontent.com/498212/54038974-ce5f6d80-418f-11e9-9bca-c3271fe2404a.gif)

</details>

We can discuss how these might get contributed back to @52inc's library once Local Discovery has shipped 👍 